### PR TITLE
dl: delete blank line from codereview.cfg

### DIFF
--- a/codereview.cfg
+++ b/codereview.cfg
@@ -1,2 +1,1 @@
 issuerepo: golang/go
-


### PR DESCRIPTION
It's not needed. It's not there in other subrepos:

- https://github.com/golang/image/blob/c73c2afc3b812cdd6385de5a50616511c4a3d458/codereview.cfg
- https://github.com/golang/net/blob/161cd47e91fd58ac17490ef4d742dc98bb4cf60e/codereview.cfg

Using this to test PRs for golang/go#26949.