### PR TITLE
internal/version: download versions to gopath

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -446,11 +446,15 @@ func exe() string {
 }
 
 func goroot(version string) (string, error) {
+	gopath, found := os.LookupEnv("GOPATH")
+	if found {
+		return filepath.Join(gopath, "sdk", version), nil
+	}
 	home, err := homedir()
 	if err != nil {
 		return "", fmt.Errorf("failed to get home directory: %v", err)
 	}
-	return filepath.Join(home, "sdk", version), nil
+	return filepath.Join(home, "go", "sdk", version), nil
 }
 
 func homedir() (string, error) {


### PR DESCRIPTION
Download and unpack versions under `$GOPATH/sdk`.

Fixes golang/go#26520