### PR TITLE
gotip: don't assume origin as the git remote name

### DIFF
--- a/internal/version/gotip.go
+++ b/internal/version/gotip.go
@@ -71,7 +71,7 @@ func installTip(root, target string) error {
 		if err := os.MkdirAll(root, 0755); err != nil {
 			return fmt.Errorf("failed to create repository: %v", err)
 		}
-		if err := git("clone", "--depth=1", "https://go.googlesource.com/go", root); err != nil {
+		if err := git("clone", "--origin=origin", "--depth=1", "https://go.googlesource.com/go", root); err != nil {
 			return fmt.Errorf("failed to clone git repository: %v", err)
 		}
 	}


### PR DESCRIPTION
When running "gotip download", we try to update the gotip working tree
by running several git commands with the hard-coded name "origin". The
name "origin" is the default in git, but this is configurable, so it's
not necessarily safe to assume that a remote named "origin" will always
exist.

We can, however, force the name "origin" when doing the initial clone,
so that later git operations that interact with the remote can safely
assume that the name "origin" exists. This isn't totally reliable,
because if a user manually renames the remote, the commands that assume
"origin" will still fail. This change, though, ensures that the default
configuration will work even if a user has set clone.defaultRemoteName
in their local git configuration.
